### PR TITLE
Add rel noopener noreferrer to Facebook link in Modal

### DIFF
--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -60,6 +60,7 @@ const Modal = ({ isOpen, onClose, product }) => {
              <a
                 href="https://www.facebook.com/100092840949249"
                 target="_blank"
+                rel="noopener noreferrer"
               >
             <button className="modal-buy-button">
                 Facebook


### PR DESCRIPTION
## Summary
- add `rel="noopener noreferrer"` to external Facebook link in Modal component for security

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897744aaf3c832a82e6ad16a500c2fb