### PR TITLE
Throttle back-to-top scroll listener

### DIFF
--- a/src/components/BackToTopButton/BackToTopButton.jsx
+++ b/src/components/BackToTopButton/BackToTopButton.jsx
@@ -1,22 +1,46 @@
 // src/components/BackToTopButton/BackToTopButton.jsx
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import { FaArrowUp } from "react-icons/fa"; // Sử dụng icon mũi tên từ react-icons
 import "./BackToTopButton.css";
+
+// Hàm throttle đơn giản để giới hạn tần suất gọi hàm
+function throttle(fn, delay) {
+  let timeoutId = null;
+  const throttled = (...args) => {
+    if (timeoutId === null) {
+      fn(...args);
+      timeoutId = setTimeout(() => {
+        timeoutId = null;
+      }, delay);
+    }
+  };
+  throttled.cancel = () => {
+    if (timeoutId !== null) {
+      clearTimeout(timeoutId);
+      timeoutId = null;
+    }
+  };
+  return throttled;
+}
 
 const BackToTopButton = () => {
   // State để theo dõi việc nút có nên hiển thị hay không
   const [isVisible, setIsVisible] = useState(false);
 
-  // Hàm kiểm tra vị trí cuộn và cập nhật state
-  const toggleVisibility = () => {
-    if (window.scrollY > 300) {
-      // Hiện nút nếu cuộn xuống hơn 300px
-      setIsVisible(true);
-    } else {
-      setIsVisible(false);
-    }
-  };
+  // Hàm kiểm tra vị trí cuộn và cập nhật state (được throttle)
+  const toggleVisibility = useMemo(
+    () =>
+      throttle(() => {
+        if (window.scrollY > 300) {
+          // Hiện nút nếu cuộn xuống hơn 300px
+          setIsVisible(true);
+        } else {
+          setIsVisible(false);
+        }
+      }, 200),
+    []
+  );
 
   // Hàm để cuộn lên đầu trang
   const scrollToTop = () => {
@@ -28,14 +52,15 @@ const BackToTopButton = () => {
 
   useEffect(() => {
     // Thêm một trình lắng nghe sự kiện 'scroll' khi component được tạo
-    window.addEventListener("scroll", toggleVisibility);
+    window.addEventListener("scroll", toggleVisibility, { passive: true });
 
     // Dọn dẹp trình lắng nghe sự kiện khi component bị hủy
     // Đây là bước quan trọng để tránh rò rỉ bộ nhớ!
     return () => {
       window.removeEventListener("scroll", toggleVisibility);
+      toggleVisibility.cancel();
     };
-  }, []);
+  }, [toggleVisibility]);
 
   return (
     <div className="back-to-top">


### PR DESCRIPTION
## Summary
- throttle back-to-top scroll handler to reduce frequency of state updates
- add passive option to scroll event listener and cancel throttled handler on cleanup

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: /workspace/fcsgo/src/pages/Empire/Empire.jsx:73:14 'err' is defined but never used)*

------
https://chatgpt.com/codex/tasks/task_e_68977434cf28832a9a2a8ac908129e04