### PR TITLE
Use absolute paths in Link components

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -27,7 +27,7 @@ const Header = ({ navItems }) => {
           {navItems &&
             navItems.map((item) => (
               <li key={item.id}>
-                <Link to={item.id} onClick={toggleMenu}>
+                <Link to={`/${item.id}`} onClick={toggleMenu}>
                   {item.title}
                 </Link>
               </li>

--- a/src/components/ProductListSection/ProductListSection.jsx
+++ b/src/components/ProductListSection/ProductListSection.jsx
@@ -11,7 +11,7 @@ const ProductListSection = ({ id, title, products }) => {
     <section id={id} className="product-list-section">
       <div className="product-list-section__header">
         <h2 className="product-list-section__title">{title}</h2>
-        <Link to={id} className="product-list-section__view-all">
+        <Link to={`/${id}`} className="product-list-section__view-all">
           Xem Thêm ›
         </Link>
       </div>

--- a/src/pages/Empire/Empire.jsx
+++ b/src/pages/Empire/Empire.jsx
@@ -70,9 +70,10 @@ function Empire() {
       } else {
         setError("Gửi đơn hàng thất bại!");
       }
-    } catch (err) {
-      setError("Có lỗi khi gửi đơn hàng!");
-    }
+      } catch (err) {
+        console.error(err);
+        setError("Có lỗi khi gửi đơn hàng!");
+      }
 
     setLoading(false);
   };


### PR DESCRIPTION
## Summary
- Ensure product list "View All" button links to an absolute route
- Make header navigation links use absolute paths
- Log caught errors on Empire page to resolve linter warning

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897700bfd74832abcba0c7a509cadf1