### PR TITLE
Log errors for failed Empire orders

### DIFF
--- a/src/pages/Empire/Empire.jsx
+++ b/src/pages/Empire/Empire.jsx
@@ -70,9 +70,10 @@ function Empire() {
       } else {
         setError("Gửi đơn hàng thất bại!");
       }
-    } catch (err) {
-      setError("Có lỗi khi gửi đơn hàng!");
-    }
+      } catch (err) {
+        console.error("Failed to send order", err);
+        setError("Có lỗi khi gửi đơn hàng!");
+      }
 
     setLoading(false);
   };


### PR DESCRIPTION
## Summary
- log errors when Empire order submissions fail

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68976eb6f890832aa6342f1bb9a6daa2